### PR TITLE
Remove fly.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Free tier of Heroku Dynos, Postgres and Data for Redis will no longer be availab
 | [deta.sh](https://www.deta.sh/) | Build & deploy your ideas on the universe's most developer friendly cloud platform. |
 | [dokku.com](https://dokku.com/) | An open source PAAS alternative to Heroku. |
 | [domcloud.co](https://domcloud.co/) | It's like those modern hosting platforms, but for the old school. |
-| [fly.io](https://fly.io/) | Run your full stack apps (and databases!) all over the world. No ops required. |
 | [koyeb.com](https://www.koyeb.com) | For deploying full stack apps and APIs globally. Enjoy high-end performance thanks to fully automated deployments to BareMetal servers and our built-in edge network. |
 | [netlify.com](https://www.netlify.com/) | Free static site hosting with GitHub integration |
 | [northflank.com](https://www.northflank.com/) | Deploy any code, job, or database in seconds. |


### PR DESCRIPTION
Fly.io no longer offers a free plan.

[fly.io pricing](https://fly.io/plans)